### PR TITLE
Fix check type constants backward compatibility and IsToGo() method c…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -510,6 +510,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - **Solution**: Updated Customer user setup to include `SECURITY_SETTLE` permission in addition to existing `SECURITY_TABLES` and `SECURITY_ORDER`
   - **Implementation**: Modified all three Customer user creation locations in `main/terminal.cc` to grant proper permissions
   - **Result**: SelfOrder terminals can now properly access drawers for payment processing without errors
+- **Check Type Constants Backward Compatibility**: Fixed data corruption issue caused by renumbering existing check type constants
+  - **Problem**: Renumbering `CHECK_DINEIN`, `CHECK_TOGO`, and `CHECK_CALLIN` from values 11-13 to 13-15 broke backward compatibility
+  - **Impact**: Saved checks with old type values (11 for `CHECK_DINEIN`) were misinterpreted as new types like `CHECK_SELFDINEIN`, causing incorrect behavior and data corruption
+  - **Solution**: Restored original values for existing constants and reassigned new values to `CHECK_SELFDINEIN` and `CHECK_SELFTAKEOUT`
+  - **New Values**: `CHECK_DINEIN`=11, `CHECK_TOGO`=12, `CHECK_CALLIN`=13, `CHECK_SELFDINEIN`=14, `CHECK_SELFTAKEOUT`=15
+  - **Result**: Existing saved checks with old type values now work correctly without data corruption
+- **IsToGo() Method Consistency**: Fixed inconsistency in `IsToGo()` method to include `CHECK_SELFTAKEOUT`
+  - **Problem**: `IsToGo()` method didn't account for `CHECK_SELFTAKEOUT`, creating inconsistency with other related methods
+  - **Impact**: Self-service takeout orders (`CHECK_SELFTAKEOUT`) were not properly identified as "to go" orders
+  - **Solution**: Updated `IsToGo()` method to include `CHECK_SELFTAKEOUT` check type
+  - **Consistency**: Now matches pattern used in `IsTakeOut()` and `IsForHere()` methods which include their corresponding self-service types
+  - **Result**: Self-service takeout orders are now correctly identified as "to go" orders
 - Allow settlement after reset for users with Settle permission
   - Removed terminal-type restriction in `Terminal::CanSettleCheck()` that blocked settling on `ORDER_ONLY` terminals after reset
   - Settlement still requires a valid drawer and respects ownership/supervisor checks

--- a/main/check.cc
+++ b/main/check.cc
@@ -2577,7 +2577,8 @@ int Check::IsToGo()
    FnTrace("Check::IsToGo()");
    int ct = CustomerType();
    return ct == CHECK_TOGO || 
-          ct == CHECK_TAKEOUT;
+          ct == CHECK_TAKEOUT ||
+          ct == CHECK_SELFTAKEOUT;
 }
 
 int Check::IsForHere()

--- a/main/check.hh
+++ b/main/check.hh
@@ -44,11 +44,11 @@
 #define CHECK_RETAIL         8
 #define CHECK_FASTFOOD       9
 #define CHECK_SELFORDER     10   // customer self-service order - no login required
-#define CHECK_SELFDINEIN    11   // customer self-service dine-in order
-#define CHECK_SELFTAKEOUT   12   // customer self-service take-out order
-#define CHECK_DINEIN        13
-#define CHECK_TOGO          14
-#define CHECK_CALLIN        15
+#define CHECK_DINEIN        11   // dine-in order (restored original value for backward compatibility)
+#define CHECK_TOGO          12   // take-out order (restored original value for backward compatibility)
+#define CHECK_CALLIN        13   // call-in order (restored original value for backward compatibility)
+#define CHECK_SELFDINEIN    14   // customer self-service dine-in order
+#define CHECK_SELFTAKEOUT   15   // customer self-service take-out order
 
 // Check Flags
 #define CF_PRINTED           1   // Has been sent to the kitcen at least once


### PR DESCRIPTION
…onsistency

- Restore original values for CHECK_DINEIN (11), CHECK_TOGO (12), CHECK_CALLIN (13) to maintain backward compatibility
- Reassign CHECK_SELFDINEIN (14) and CHECK_SELFTAKEOUT (15) to avoid conflicts
- Fix IsToGo() method to include CHECK_SELFTAKEOUT for consistency with other methods
- Prevents data corruption from existing saved checks with old type values
- Ensures self-service takeout orders are properly identified as 'to go' orders