### PR TITLE
Fix parse_price handling of currency symbols

### DIFF
--- a/src/utils/string_utils.cc
+++ b/src/utils/string_utils.cc
@@ -214,16 +214,16 @@ namespace vt_string {
         std::string cleaned = trim(str);
         if (cleaned.empty()) return false;
         
-        // Remove $ sign if present
-        if (cleaned[0] == '$') {
-            cleaned = cleaned.substr(1);
-        }
-        
-        // Handle negative values
+        // Extract sign information regardless of whether the currency symbol
+        // appears before or after it (e.g. "$-12.34" or "-$12.34").
         bool negative = false;
-        if (!cleaned.empty() && cleaned[0] == '-') {
-            negative = true;
-            cleaned = cleaned.substr(1);
+
+        cleaned.erase(std::remove(cleaned.begin(), cleaned.end(), '$'), cleaned.end());
+        cleaned = trim(cleaned);
+
+        if (!cleaned.empty() && (cleaned[0] == '+' || cleaned[0] == '-')) {
+            negative = cleaned[0] == '-';
+            cleaned = trim(cleaned.substr(1));
         }
         
         // Remove commas


### PR DESCRIPTION
## Summary
- ensure parse_price accepts inputs where the currency symbol precedes or follows the sign
- trim whitespace around the value after removing currency markers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4a3ec4f483329f97e68e1eb76699

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update parse_price to accept signs before or after '$', handle optional '+', remove all '$', and re-trim input.
> 
> - **Price parsing (`src/utils/string_utils.cc`)**:
>   - Remove all occurrences of `$` before parsing and re-trim the value.
>   - Accept leading `+` or `-` sign after cleanup, supporting inputs like `$-12.34` and `-$12.34`.
>   - Preserve existing comma removal and decimal handling logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4347a57999050a943c418ccf2040d7049ec2e7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->