### PR TITLE
Fix parse_price handling of currency symbols

### DIFF
--- a/src/utils/string_utils.cc
+++ b/src/utils/string_utils.cc
@@ -214,16 +214,16 @@ namespace vt_string {
         std::string cleaned = trim(str);
         if (cleaned.empty()) return false;
         
-        // Remove $ sign if present
-        if (cleaned[0] == '$') {
-            cleaned = cleaned.substr(1);
-        }
-        
-        // Handle negative values
+        // Extract sign information regardless of whether the currency symbol
+        // appears before or after it (e.g. "$-12.34" or "-$12.34").
         bool negative = false;
-        if (!cleaned.empty() && cleaned[0] == '-') {
-            negative = true;
-            cleaned = cleaned.substr(1);
+
+        cleaned.erase(std::remove(cleaned.begin(), cleaned.end(), '$'), cleaned.end());
+        cleaned = trim(cleaned);
+
+        if (!cleaned.empty() && (cleaned[0] == '+' || cleaned[0] == '-')) {
+            negative = cleaned[0] == '-';
+            cleaned = trim(cleaned.substr(1));
         }
         
         // Remove commas


### PR DESCRIPTION
## Summary

This PR fixes the `parse_price` function in `string_utils.cc` to properly handle currency symbols in various formats.

## Changes

- Improved handling of currency symbols ($) that can appear before or after negative signs (e.g., "$-12.34" or "-$12.34")
- Fixed sign extraction to work correctly regardless of currency symbol position
- Removed old sequential character-by-character approach in favor of a more robust solution using `std::remove`
- Added support for both '+' and '-' sign prefixes

## Files Changed

- `src/utils/string_utils.cc`: Updated `parse_price` function logic

## Testing

The fix ensures that price strings with currency symbols are correctly parsed regardless of where the currency symbol appears in relation to the sign.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `parse_price` to strip `$` regardless of position and correctly parse leading `+` or `-` signs.
> 
> - **`src/utils/string_utils.cc`**:
>   - **`parse_price`**:
>     - Remove all `$` symbols before parsing, handling inputs like "$-12.34" or "-$12.34".
>     - Extract sign from leading `+` or `-` after symbol removal and trimming.
>     - Keep existing comma removal and decimal parsing logic intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9979273c8de5258fe579af05e8552afab82959a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->